### PR TITLE
森永の追加　出力画像のフォルダにグレースケール化されてない画像があった場合の対応＆入出力ディレクトリの画像数の調整

### DIFF
--- a/ImageProcessor/image_process_Gray.py
+++ b/ImageProcessor/image_process_Gray.py
@@ -6,11 +6,11 @@ import cv2
 OUT_DIR = "image_gray/"
 
 def ready():
-    #image_addディレクトリにあるファイル名のリスト
+    #入力画像ディレクトリにあるファイル名のリスト
     add_files = os.listdir("image_add")
-    #image_grayディレクトリにあるファイル名のリスト
+    #出力画像ディレクトリにあるファイル名のリスト
     gray_files = os.listdir("image_gray")
-    #image_addにある画像の中でグレースケール化されてない画像を見つける
+    #入力画像ディレクトリにある画像の中でグレースケール化されてない画像を見つける
     notgray_files = [i for i in add_files if not i in gray_files]
     #全てグレースケール化する
     for notgray_file in notgray_files:
@@ -21,7 +21,7 @@ def ready():
         #画像保存
         cv2.imwrite(OUT_DIR + notgray_file,gray)
     
-    #image_grayディレクトリにあるファイル名のリスト
+    #出力画像ディレクトリにあるファイル名のリスト
     gray_files = os.listdir("image_gray")
     #全てグレースケール化
     for gray_file in gray_files:

--- a/ImageProcessor/image_process_Gray.py
+++ b/ImageProcessor/image_process_Gray.py
@@ -3,11 +3,8 @@ import time
 import sys
 import cv2
 
-# スクリプト実行用ディレクトリを絶対パスで指定する
-BASEDIR = os.path.abspath(os.path.dirname(__file__))
 OUT_DIR = "image_gray/"
 
-#初期状態の処理
 def ready():
     #image_addディレクトリにあるファイル名のリスト
     add_files = os.listdir("image_add")
@@ -23,6 +20,20 @@ def ready():
         gray = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
         #画像保存
         cv2.imwrite(OUT_DIR + notgray_file,gray)
+    
+    #image_grayディレクトリにあるファイル名のリスト
+    gray_files = os.listdir("image_gray")
+    #全てグレースケール化
+    for gray_file in gray_files:
+        #画像を読み込む
+        img2 = cv2.imread(OUT_DIR + gray_file)
+        #上記で読み込んだファイルを削除
+        os.remove(OUT_DIR + gray_file)
+        #グレースケール化
+        gray = cv2.cvtColor(img2, cv2.COLOR_RGB2GRAY)
+        #画像保存
+        cv2.imwrite(OUT_DIR + gray_file,gray)
+
 
 if __name__ in '__main__':
     # 処理が終了しないようにスリープを挟んで無限ループ

--- a/ImageProcessor/image_process_Gray.py
+++ b/ImageProcessor/image_process_Gray.py
@@ -5,7 +5,10 @@ import cv2
 
 OUT_DIR = "image_gray/"
 
-def ready():
+"""
+関数説明：入力画像ディレクトリにある画像を全てグレースケール化する
+"""
+def Turn_image_add_into_Gray():
     #入力画像ディレクトリにあるファイル名のリスト
     add_files = os.listdir("image_add")
     #出力画像ディレクトリにあるファイル名のリスト
@@ -20,7 +23,11 @@ def ready():
         gray = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
         #画像保存
         cv2.imwrite(OUT_DIR + notgray_file,gray)
-    
+
+"""
+関数説明：出力画像ディレクトリにある画像を全てグレースケール化する
+"""
+def Turn_image_gray_into_Gray():   
     #出力画像ディレクトリにあるファイル名のリスト
     gray_files = os.listdir("image_gray")
     #全てグレースケール化
@@ -34,10 +41,27 @@ def ready():
         #画像保存
         cv2.imwrite(OUT_DIR + gray_file,gray)
 
+"""
+関数説明：入力画像ディレクトリにある画像の数と出力画像ディレクトリにある画像の数を等しくする関数
+"""
+def Adjust_the_number_of_files():
+    #入力画像ディレクトリにあるファイル名のリスト
+    add_files = os.listdir("image_add")
+    #出力画像ディレクトリにあるファイル名のリスト
+    gray_files = os.listdir("image_gray")
+    #出力画像ディレクトリから入力画像ディレクトリに存在しないファイル名を削除
+    none_exit_in_add_files = [i for i in gray_files if not i in add_files]
+    for none_exit_in_add_file in none_exit_in_add_files:
+        #上記で読み込んだファイルを削除
+        os.remove(OUT_DIR + none_exit_in_add_file)
+    
+
 
 if __name__ in '__main__':
     # 処理が終了しないようにスリープを挟んで無限ループ
     while True:
         # 1秒ごとに監視
         time.sleep(1)
-        ready()
+        Turn_image_add_into_Gray()
+        Turn_image_gray_into_Gray()
+        Adjust_the_number_of_files()


### PR DESCRIPTION
動作確認をしたところ、出力画像のフォルダ(image_gray)の中にグレースケール化されてない画像があった場合、その画像はグレースケール化されないままになっていることに気付きました。
そのため、image_grayフォルダの中にある画像は必ずグレースケール化するように修正しました。
それと、余分なコードの削除とコメント文の修正も行いました。